### PR TITLE
⚡ Bolt: Cache local Minecraft versions

### DIFF
--- a/src/main/kotlin/one/pkg/modpublish/util/io/VersionProcessor.kt
+++ b/src/main/kotlin/one/pkg/modpublish/util/io/VersionProcessor.kt
@@ -26,6 +26,7 @@ import one.pkg.modpublish.api.NetworkUtil
 import one.pkg.modpublish.util.io.FileAPI.getUserDataFile
 import one.pkg.modpublish.util.io.JsonParser.fromJson
 import one.pkg.modpublish.util.io.JsonParser.toJson
+import one.pkg.modpublish.util.resources.LocalResources
 import java.io.File
 import java.io.IOException
 import java.nio.charset.StandardCharsets
@@ -184,7 +185,11 @@ object VersionProcessor {
         val curseforge = fetchCurseforgeVersions() ?: return false
         val mapping = createVersionMapping(curseforge)
         val merged = mergeCurseforgeIds(mojang, mapping)
-        return saveVersions(merged, "minecraft.version.json".getUserDataFile())
+        val saved = saveVersions(merged, "minecraft.version.json".getUserDataFile())
+        if (saved) {
+            LocalResources.clearMinecraftVersionsCache()
+        }
+        return saved
         //showPreview(merged, 5);
     }
 

--- a/src/main/kotlin/one/pkg/modpublish/util/resources/LocalResources.kt
+++ b/src/main/kotlin/one/pkg/modpublish/util/resources/LocalResources.kt
@@ -31,6 +31,7 @@ import java.lang.reflect.Type
 object LocalResources {
     val dpType: Type = object : TypeToken<List<DependencyInfo>>() {}.type
     private val mvType = object : TypeToken<List<MinecraftVersion>>() {}.type
+    private var cachedMinecraftVersions: List<MinecraftVersion>? = null
 
     @Throws(
         ResourcesNotFoundException::class,
@@ -51,7 +52,11 @@ object LocalResources {
         SecurityException::class,
         NullPointerException::class
     )
+    // Cache the result to avoid repeated file IO and JSON parsing on every call.
+    @Synchronized
     fun getMinecraftVersions(): List<MinecraftVersion> {
+        cachedMinecraftVersions?.let { return it }
+
         val localFile = "minecraft.version.json".getUserDataFile()
         val stream = if (localFile.exists()) FileInputStream(localFile)
         else LocalResources.javaClass.getResourceAsStream("/META-INF/minecraft.version.json")
@@ -59,6 +64,12 @@ object LocalResources {
             InputStreamReader(it).use { reader ->
                 reader.fromJson<List<MinecraftVersion>>(mvType)
             }
-        } ?: throw ResourcesNotFoundException("minecraft.version.json not found")
+        }?.also { cachedMinecraftVersions = it }
+            ?: throw ResourcesNotFoundException("minecraft.version.json not found")
+    }
+
+    @Synchronized
+    fun clearMinecraftVersionsCache() {
+        cachedMinecraftVersions = null
     }
 }


### PR DESCRIPTION
Implemented a read-through cache for `MinecraftVersion` list in `LocalResources` to avoid repeated disk I/O and JSON parsing. Added explicit cache invalidation in `VersionProcessor` to ensure data consistency after updates.

---
*PR created automatically by Jules for task [15585213490795270855](https://jules.google.com/task/15585213490795270855) started by @404Setup*