### PR TITLE
fix: Make CurseForge Studio API token optional for publishing

### DIFF
--- a/src/main/kotlin/one/pkg/modpublish/settings/properties/Property.kt
+++ b/src/main/kotlin/one/pkg/modpublish/settings/properties/Property.kt
@@ -40,8 +40,7 @@ data class Property(
         val modid: String
     ) : PropertyBase {
         override fun isEnabled(): Boolean {
-            return !token.data.trim { it <= ' ' }.isEmpty() && !studioToken.data.trim { it <= ' ' }
-                .isEmpty() && !modid.trim { it <= ' ' }.isEmpty()
+            return !token.data.trim { it <= ' ' }.isEmpty() && !modid.trim { it <= ' ' }.isEmpty()
         }
 
         companion object {

--- a/src/main/kotlin/one/pkg/modpublish/ui/AddDependencyDialog.kt
+++ b/src/main/kotlin/one/pkg/modpublish/ui/AddDependencyDialog.kt
@@ -25,6 +25,7 @@ import one.pkg.modpublish.data.internal.PublishTarget
 import one.pkg.modpublish.data.internal.Selector
 import one.pkg.modpublish.data.local.DependencyInfo
 import one.pkg.modpublish.data.local.DependencyType
+import one.pkg.modpublish.settings.properties.Properties.getProperties
 import one.pkg.modpublish.ui.base.BaseDialogWrapper
 import java.awt.GridBagConstraints
 import java.awt.GridBagLayout
@@ -91,7 +92,14 @@ class AddDependencyDialog(
         resultDependency = DependencyInfo(projectId, selectedType, null)
 
         validateDependency(resultDependency).apply {
-            modrinth?.failed?.let { showFailedDialogRaw(it, get("title.failed")) }
+            modrinth?.failed?.let {
+                showFailedDialogRaw(it, get("title.failed"))
+                return
+            }
+            curseForge?.failed?.let {
+                showFailedDialogRaw(it, get("title.failed"))
+                return
+            }
 
             modrinth?.let { resultDependency.apply { customTitle = it.name; modrinthModInfo = it } }
             curseForge?.let { resultDependency.apply { customTitle = it.name; curseforgeModInfo = it } }
@@ -116,6 +124,9 @@ class AddDependencyDialog(
             } else null
 
             val curseforgeInfo = if (selector.curseForge && parts[1].isNotBlank()) {
+                if (getProperties(requireNotNull(project)).curseforge.studioToken.failed) {
+                    return ModInfos(null, ModInfo.of(get("failed.11")))
+                }
                 PublishTarget.CurseForge.api.getModInfo(parts[1], requireNotNull(project)).also {
                     if (it.failed != null) return ModInfos(null, it)
                 }
@@ -129,6 +140,9 @@ class AddDependencyDialog(
             } else null
 
             val curseforgeInfo = if (selector.curseForge) {
+                if (getProperties(requireNotNull(project)).curseforge.studioToken.failed) {
+                    return ModInfos(null, ModInfo.of(get("failed.11")))
+                }
                 PublishTarget.CurseForge.api.getModInfo(projectId, requireNotNull(project)).also {
                     if (it.failed != null) return ModInfos(null, it)
                 }

--- a/src/main/kotlin/one/pkg/modpublish/ui/PublishModDialog.kt
+++ b/src/main/kotlin/one/pkg/modpublish/ui/PublishModDialog.kt
@@ -419,7 +419,7 @@ class PublishModDialog(
         if (!p2.curseforge.isEnabled()) {
             curseforgeCheckBox.isEnabled = false
             curseforgeCheckBox.toolTipText = get("tooltip.curseforge.disable")
-        } else if (p2.curseforge.token.failed || p2.curseforge.studioToken.failed) {
+        } else if (p2.curseforge.token.failed) {
             curseforgeCheckBox.setFailedSelect()
         }
 

--- a/src/main/resources/messages/ModPublish.properties
+++ b/src/main/resources/messages/ModPublish.properties
@@ -113,3 +113,4 @@ dialog.modpublish.config-project.repo=Repo:
 dialog.modpublish.config-project.repo.tooltips=Format: user/repoName
 dialog.modpublish.config-project.branch=Branch:
 dialog.modpublish.config-project.branch.tooltips=If not specified, branches will be pulled automatically in this order: current local branch, remote default branch
+failed.11=CurseForge Studio API Token is missing or invalid

--- a/src/main/resources/messages/ModPublish_de.properties
+++ b/src/main/resources/messages/ModPublish_de.properties
@@ -113,3 +113,4 @@ dialog.modpublish.config-project.repo=Repository:
 dialog.modpublish.config-project.repo.tooltips=Format: benutzer/repoName
 dialog.modpublish.config-project.branch=Branch:
 dialog.modpublish.config-project.branch.tooltips=Wenn nicht angegeben, werden Branches automatisch in dieser Reihenfolge abgerufen: aktueller lokaler Branch, Standard-Branch des Remote-Repositories
+failed.11=CurseForge Studio API Token is missing or invalid

--- a/src/main/resources/messages/ModPublish_de.properties
+++ b/src/main/resources/messages/ModPublish_de.properties
@@ -113,4 +113,4 @@ dialog.modpublish.config-project.repo=Repository:
 dialog.modpublish.config-project.repo.tooltips=Format: benutzer/repoName
 dialog.modpublish.config-project.branch=Branch:
 dialog.modpublish.config-project.branch.tooltips=Wenn nicht angegeben, werden Branches automatisch in dieser Reihenfolge abgerufen: aktueller lokaler Branch, Standard-Branch des Remote-Repositories
-failed.11=CurseForge Studio API Token is missing or invalid
+failed.11=Der CurseForge Studio API-Token fehlt oder ist ungültig

--- a/src/main/resources/messages/ModPublish_es.properties
+++ b/src/main/resources/messages/ModPublish_es.properties
@@ -113,3 +113,4 @@ dialog.modpublish.config-project.repo=Repositorio:
 dialog.modpublish.config-project.repo.tooltips=Formato: usuario/nombreRepositorio
 dialog.modpublish.config-project.branch=Rama:
 dialog.modpublish.config-project.branch.tooltips=Si no se especifica, las ramas se extraerán automáticamente en este orden: rama local actual, rama remota predeterminada
+failed.11=CurseForge Studio API Token is missing or invalid

--- a/src/main/resources/messages/ModPublish_es.properties
+++ b/src/main/resources/messages/ModPublish_es.properties
@@ -113,4 +113,4 @@ dialog.modpublish.config-project.repo=Repositorio:
 dialog.modpublish.config-project.repo.tooltips=Formato: usuario/nombreRepositorio
 dialog.modpublish.config-project.branch=Rama:
 dialog.modpublish.config-project.branch.tooltips=Si no se especifica, las ramas se extraerán automáticamente en este orden: rama local actual, rama remota predeterminada
-failed.11=CurseForge Studio API Token is missing or invalid
+failed.11=Falta el token de API del Estudio CurseForge o es inválido

--- a/src/main/resources/messages/ModPublish_fr.properties
+++ b/src/main/resources/messages/ModPublish_fr.properties
@@ -113,4 +113,4 @@ dialog.modpublish.config-project.repo=Dépôt :
 dialog.modpublish.config-project.repo.tooltips=Format : utilisateur/nomDuDépôt
 dialog.modpublish.config-project.branch=Branche :
 dialog.modpublish.config-project.branch.tooltips=Si non spécifié, les branches seront automatiquement récupérées dans cet ordre : branche locale actuelle, branche distante par défaut
-failed.11=CurseForge Studio API Token is missing or invalid
+failed.11=Le jeton API Studio CurseForge est manquant ou invalide

--- a/src/main/resources/messages/ModPublish_fr.properties
+++ b/src/main/resources/messages/ModPublish_fr.properties
@@ -113,3 +113,4 @@ dialog.modpublish.config-project.repo=Dépôt :
 dialog.modpublish.config-project.repo.tooltips=Format : utilisateur/nomDuDépôt
 dialog.modpublish.config-project.branch=Branche :
 dialog.modpublish.config-project.branch.tooltips=Si non spécifié, les branches seront automatiquement récupérées dans cet ordre : branche locale actuelle, branche distante par défaut
+failed.11=CurseForge Studio API Token is missing or invalid

--- a/src/main/resources/messages/ModPublish_jp.properties
+++ b/src/main/resources/messages/ModPublish_jp.properties
@@ -113,4 +113,4 @@ dialog.modpublish.config-project.repo=リポジトリ:
 dialog.modpublish.config-project.repo.tooltips=形式: ユーザー名/リポジトリ名
 dialog.modpublish.config-project.branch=ブランチ:
 dialog.modpublish.config-project.branch.tooltips=指定されていない場合、次の順序で自動的にブランチが取得されます: 現在のローカルブランチ、リモートのデフォルトブランチ
-failed.11=CurseForge Studio API Token is missing or invalid
+failed.11=CurseForge Studio API トークンが見つからないか無効です

--- a/src/main/resources/messages/ModPublish_jp.properties
+++ b/src/main/resources/messages/ModPublish_jp.properties
@@ -113,3 +113,4 @@ dialog.modpublish.config-project.repo=リポジトリ:
 dialog.modpublish.config-project.repo.tooltips=形式: ユーザー名/リポジトリ名
 dialog.modpublish.config-project.branch=ブランチ:
 dialog.modpublish.config-project.branch.tooltips=指定されていない場合、次の順序で自動的にブランチが取得されます: 現在のローカルブランチ、リモートのデフォルトブランチ
+failed.11=CurseForge Studio API Token is missing or invalid

--- a/src/main/resources/messages/ModPublish_ko_KR.properties
+++ b/src/main/resources/messages/ModPublish_ko_KR.properties
@@ -113,3 +113,4 @@ dialog.modpublish.config-project.repo=저장소:
 dialog.modpublish.config-project.repo.tooltips=형식: 사용자/저장소이름
 dialog.modpublish.config-project.branch=브랜치:
 dialog.modpublish.config-project.branch.tooltips=지정하지 않으면 현재 로컬 브랜치, 원격 기본 브랜치 순으로 자동으로 가져옵니다
+failed.11=CurseForge Studio API Token is missing or invalid

--- a/src/main/resources/messages/ModPublish_ko_KR.properties
+++ b/src/main/resources/messages/ModPublish_ko_KR.properties
@@ -113,4 +113,4 @@ dialog.modpublish.config-project.repo=저장소:
 dialog.modpublish.config-project.repo.tooltips=형식: 사용자/저장소이름
 dialog.modpublish.config-project.branch=브랜치:
 dialog.modpublish.config-project.branch.tooltips=지정하지 않으면 현재 로컬 브랜치, 원격 기본 브랜치 순으로 자동으로 가져옵니다
-failed.11=CurseForge Studio API Token is missing or invalid
+failed.11=CurseForge Studio API 토큰이 없거나 잘못되었습니다

--- a/src/main/resources/messages/ModPublish_ru.properties
+++ b/src/main/resources/messages/ModPublish_ru.properties
@@ -114,3 +114,4 @@ dialog.modpublish.config-project.repo=Репозиторий:
 dialog.modpublish.config-project.repo.tooltips=Формат: пользователь/названиеРепозитория
 dialog.modpublish.config-project.branch=Ветка:
 dialog.modpublish.config-project.branch.tooltips=Если не указано, ветки будут автоматически подтянуты в следующем порядке: текущая локальная ветка, удаленная ветка по умолчанию
+failed.11=CurseForge Studio API Token is missing or invalid

--- a/src/main/resources/messages/ModPublish_ru.properties
+++ b/src/main/resources/messages/ModPublish_ru.properties
@@ -114,4 +114,4 @@ dialog.modpublish.config-project.repo=Репозиторий:
 dialog.modpublish.config-project.repo.tooltips=Формат: пользователь/названиеРепозитория
 dialog.modpublish.config-project.branch=Ветка:
 dialog.modpublish.config-project.branch.tooltips=Если не указано, ветки будут автоматически подтянуты в следующем порядке: текущая локальная ветка, удаленная ветка по умолчанию
-failed.11=CurseForge Studio API Token is missing or invalid
+failed.11=Студийный API токен CurseForge отсутствует или недействителен

--- a/src/main/resources/messages/ModPublish_zh_CN.properties
+++ b/src/main/resources/messages/ModPublish_zh_CN.properties
@@ -109,3 +109,4 @@ dialog.modpublish.config-project.repo=仓库:
 dialog.modpublish.config-project.repo.tooltips=填写格式: user/repoName
 dialog.modpublish.config-project.branch=分支:
 dialog.modpublish.config-project.branch.tooltips=如果未指定，系统将按以下顺序自动获取分支：当前本地分支，远程默认分支
+failed.11=未填入CurseForge Studio API密钥或其无效

--- a/src/main/resources/messages/ModPublish_zh_HK.properties
+++ b/src/main/resources/messages/ModPublish_zh_HK.properties
@@ -109,4 +109,4 @@ dialog.modpublish.config-project.repo=倉庫:
 dialog.modpublish.config-project.repo.tooltips=填寫格式: user/repoName
 dialog.modpublish.config-project.branch=分支:
 dialog.modpublish.config-project.branch.tooltips=如果未指定，系統將按此順序自動選取分支：當前本地分支，遠程預設分支
-failed.11=CurseForge Studio API Token is missing or invalid
+failed.11=未填寫CurseForge Studio API密鑰或其無效

--- a/src/main/resources/messages/ModPublish_zh_HK.properties
+++ b/src/main/resources/messages/ModPublish_zh_HK.properties
@@ -109,3 +109,4 @@ dialog.modpublish.config-project.repo=倉庫:
 dialog.modpublish.config-project.repo.tooltips=填寫格式: user/repoName
 dialog.modpublish.config-project.branch=分支:
 dialog.modpublish.config-project.branch.tooltips=如果未指定，系統將按此順序自動選取分支：當前本地分支，遠程預設分支
+failed.11=CurseForge Studio API Token is missing or invalid

--- a/src/main/resources/messages/ModPublish_zh_TW.properties
+++ b/src/main/resources/messages/ModPublish_zh_TW.properties
@@ -110,3 +110,4 @@ dialog.modpublish.config-project.repo=倉庫:
 dialog.modpublish.config-project.repo.tooltips=填寫格式: user/repoName
 dialog.modpublish.config-project.branch=分支:
 dialog.modpublish.config-project.branch.tooltips=如果未指定，系統將依以下順序自動獲取分支：目前本地分支，遠端預設分支
+failed.11=CurseForge Studio API Token is missing or invalid

--- a/src/main/resources/messages/ModPublish_zh_TW.properties
+++ b/src/main/resources/messages/ModPublish_zh_TW.properties
@@ -110,4 +110,4 @@ dialog.modpublish.config-project.repo=倉庫:
 dialog.modpublish.config-project.repo.tooltips=填寫格式: user/repoName
 dialog.modpublish.config-project.branch=分支:
 dialog.modpublish.config-project.branch.tooltips=如果未指定，系統將依以下順序自動獲取分支：目前本地分支，遠端預設分支
-failed.11=CurseForge Studio API Token is missing or invalid
+failed.11=未填寫CurseForge Studio API金鑰或其無效


### PR DESCRIPTION
Fixes an issue where the CurseForge Studio API token was required to enable the CurseForge publishing target. The token is now only required when explicitly adding CurseForge dependencies, and the UI provides correct warnings when omitted.

---
*PR created automatically by Jules for task [9793648769327224937](https://jules.google.com/task/9793648769327224937) started by @404Setup*