### PR TITLE
Fix weak machine fingerprinting for key generation

### DIFF
--- a/src/main/kotlin/one/pkg/modpublish/util/protect/HardwareFingerprint.kt
+++ b/src/main/kotlin/one/pkg/modpublish/util/protect/HardwareFingerprint.kt
@@ -16,16 +16,16 @@
  */
 package one.pkg.modpublish.util.protect
 
-import java.net.NetworkInterface
-import java.nio.charset.StandardCharsets
-import java.security.MessageDigest
-import kotlin.math.abs
+import com.intellij.credentialStore.CredentialAttributes
+import com.intellij.ide.passwordSafe.PasswordSafe
+import java.security.SecureRandom
+import java.util.Base64
 
 @Suppress("UNUSED")
 class HardwareFingerprint private constructor() {
     init {
         val about =
-            "This class is used to generate a unique security ID to prevent the user set API keys from being stolen."
+            "This class is used to retrieve or generate a unique security ID from PasswordSafe to protect API keys."
     }
 
     companion object {
@@ -33,78 +33,25 @@ class HardwareFingerprint private constructor() {
 
         val secureProjectKey: String
             get() {
-                if (key == null) key = generateKeyBase()
+                if (key == null) key = getOrGenerateKey()
                 return key!!
             }
 
-        private fun generateKeyBase(): String = runCatching {
-            val digest = MessageDigest.getInstance("SHA-256")
-            val hash = digest.digest(getPlatformBindingInfo().toByteArray(StandardCharsets.UTF_8))
-            hash.joinToString("") { "%02x".format(it) }.substring(0, 32)
-        }.getOrDefault(generateFallbackKey())
+        private fun getOrGenerateKey(): String {
+            val attributes = CredentialAttributes("ModPublish-SecureProjectKey")
+            var password = PasswordSafe.instance.getPassword(attributes)
+            if (password == null) {
+                val bytes = ByteArray(32)
+                SecureRandom().nextBytes(bytes)
+                password = Base64.getEncoder().encodeToString(bytes)
+                PasswordSafe.instance.setPassword(attributes, password)
+            }
+            return password
+        }
 
-        fun getEnvironmentFingerprint(): String = getPlatformBindingInfo()
+        fun getEnvironmentFingerprint(): String = "SecureRandomKey"
 
         fun validateEnvironmentBinding(expectedKey: String): Boolean =
             secureProjectKey == expectedKey
-
-        private fun getPlatformBindingInfo(): String = runCatching {
-            val osInfo = "OS:${System.getProperty("os.name", "unknown")}-${System.getProperty("os.arch", "unknown")}"
-            val userInfo =
-                "USER:${System.getProperty("user.name", "unknown")}-${
-                    System.getProperty("user.home", "unknown").hashCode()
-                }"
-            val macInfo = getMacAddress()?.let { "MAC:$it" }
-            val javaInfo = "JAVA:${extractMajorJavaVersion(System.getProperty("java.version", "unknown"))}"
-            val machineInfo = "MACHINE:${getStableMachineId()}"
-
-            listOfNotNull(osInfo, userInfo, macInfo, javaInfo, machineInfo)
-                .joinToString("|")
-        }.getOrDefault("FALLBACK:${getStableFallback()}")
-
-        private fun getMacAddress(): String? =
-            NetworkInterface.getNetworkInterfaces().toList()
-                .asSequence()
-                .filter { !it.isLoopback && it.hardwareAddress != null }
-                .mapNotNull { ni ->
-                    val mac = ni.hardwareAddress
-                    val name = ni.name.lowercase()
-                    val display = ni.displayName.lowercase()
-                    if (listOf("virtual", "vmware", "virtualbox", "hyper-v", "bluetooth", "loopback")
-                            .any { display.contains(it) } || listOf("veth", "docker").any { name.startsWith(it) } ||
-                        name.startsWith("br-") || name.startsWith("virbr") || (mac[0].toInt() and 0x02 != 0)
-                    ) return@mapNotNull null
-                    mac.joinToString(":") { "%02X".format(it) }
-                }.minOrNull()
-
-        private fun extractMajorJavaVersion(version: String): String = runCatching {
-            val parts = version.split(".")
-            if (version.startsWith("1.") && parts.size >= 2) "1.${parts[1]}" else parts[0]
-        }.getOrDefault(version)
-
-        private fun getStableMachineId(): String = listOfNotNull(
-            System.getProperty("user.home")?.takeIf { it.isNotEmpty() }?.let { "HOME:${it.hashCode()}" },
-            "CPU:${Runtime.getRuntime().availableProcessors()}",
-            "ARCH:${System.getProperty("os.arch", "unknown")}",
-            "SEP:${System.getProperty("file.separator", "/").hashCode()}"
-        ).joinToString("-")
-
-        private fun getStableFallback(): String {
-            val userName = System.getProperty("user.name", "unknown")
-            val userHomeHash = System.getProperty("user.home", "unknown").hashCode()
-            val osName = System.getProperty("os.name", "unknown")
-            return listOf(userName, userHomeHash, osName).hashCode().toString()
-        }
-
-        private fun generateFallbackKey(): String {
-            val hash = abs(getStableFallback().hashCode())
-            return "%032d".format(hash).substring(0, 32)
-        }
-
-        private fun <T> java.util.Enumeration<T>.toList(): List<T> {
-            val list = mutableListOf<T>()
-            while (hasMoreElements()) list.add(nextElement())
-            return list
-        }
     }
 }


### PR DESCRIPTION
🎯 **What:**
The vulnerability was in the way the project generated its encryption key. It derived a key from predictable hardware and OS identifiers like MAC address, Java version, and OS name.

⚠️ **Risk:**
Using environment characteristics for key generation provides a false sense of security. An attacker who gains access to the encrypted data (e.g., config files) could easily guess or obtain these environment details, recreate the key, and decrypt sensitive information. 

🛡️ **Solution:**
Replaced the `generateKeyBase` logic with the robust `PasswordSafe` API provided by the IntelliJ Platform. Now, instead of generating a predictable key, a secure 32-byte key is randomly generated using `SecureRandom` and securely stored within the user's keychain via `PasswordSafe`. All unsafe fallback and hardware gathering methods were removed.

---
*PR created automatically by Jules for task [12672225748780735389](https://jules.google.com/task/12672225748780735389) started by @404Setup*