### PR TITLE
refactor: Simplify null check in GithubAPI.kt with elvis operator

### DIFF
--- a/src/main/kotlin/one/pkg/modpublish/api/GithubAPI.kt
+++ b/src/main/kotlin/one/pkg/modpublish/api/GithubAPI.kt
@@ -43,15 +43,14 @@ class GithubAPI : API() {
     override fun createVersion(data: PublishData, project: Project): PublishResult {
         return runCatching {
             val tagName = if (data.versionNumber.startsWith("v")) data.versionNumber else "v${data.versionNumber}"
-            var existingRelease = checkExistingRelease(tagName, project)?.asJsonObject
-            if (existingRelease == null) {
+            val existingRelease = checkExistingRelease(tagName, project)?.asJsonObject ?: run {
                 val result = createRelease(data, project)
                 if (result is PublishResult) return result
-                existingRelease = (result as BackResult).asString().fromJson().asJsonObject
+                (result as BackResult).asString().fromJson().asJsonObject
             }
 
             val uploadUrl =
-                existingRelease?.get("upload_url")?.asString?.split("{")?.first() ?: return PublishResult.create(
+                existingRelease.get("upload_url")?.asString?.split("{")?.first() ?: return PublishResult.create(
                     this,
                     "Failed to get upload URL"
                 )


### PR DESCRIPTION
🎯 **What:** Simplified a null check in `GithubAPI.kt` by replacing a `var` and `if (null)` block with a `val` combined with the Elvis operator (`?:`) and a `run` block. Also removed an unnecessary safe call operator (`?.`) since the variable is now strictly non-null.
💡 **Why:** This refactoring improves the maintainability and readability of the codebase by adhering to idiomatic Kotlin principles (preferring immutability and concise null-handling syntax).
✅ **Verification:** Verified by compiling the project successfully and running `./gradlew check` which passed all validations and test suites. Additionally, reviewed the structural change to ensure logic equivalence is maintained (due to Kotlin's inline properties of `run` and `runCatching` handling the returns).
✨ **Result:** Cleaner, safer, and more idiomatic Kotlin code with improved readability without behavior changes.

---
*PR created automatically by Jules for task [18007451277622122111](https://jules.google.com/task/18007451277622122111) started by @404Setup*