### PR TITLE
optimize intermediate collections in PublishModDialog

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-19 - Removed intermediate collections on the EDT
+**Learning:** In IntelliJ plugin development, UI component processing steps like `.filter{}.forEach{}` or `.asSequence().mapNotNull{}.toList()` can be problematic if they introduce extra memory allocation for small lists on the Event Dispatch Thread.
+**Action:** Replace `filter/forEach` combinations with a direct `forEach` and an `if` statement to avoid allocating temporary `ArrayList` instances, and remove `.asSequence()` for very small lists (e.g., 6 enum values) where eager evaluation is actually faster and allocates fewer objects than sequence wrappers.

--- a/src/main/kotlin/one/pkg/modpublish/ui/PublishModDialog.kt
+++ b/src/main/kotlin/one/pkg/modpublish/ui/PublishModDialog.kt
@@ -328,9 +328,13 @@ class PublishModDialog(
                 minecraftVersions = LocalResources.getMinecraftVersions()
             }
 
-            minecraftVersions.orEmpty()
-                .filter { it.type == "release" || (includeSnapshots && it.type == "snapshot") }
-                .forEach { minecraftVersionModel.addElement(MinecraftVersionItem(it, false)) }
+            // Performance: Replaced .filter {}.forEach {} with .forEach { if () {} }
+            // to avoid allocating an intermediate collection on the EDT.
+            minecraftVersions.orEmpty().forEach {
+                if (it.type == "release" || (includeSnapshots && it.type == "snapshot")) {
+                    minecraftVersionModel.addElement(MinecraftVersionItem(it, false))
+                }
+            }
 
             autoFillMinecraftVersions()
         }
@@ -536,8 +540,10 @@ class PublishModDialog(
     }
 
     private fun collectPublishData(): PublishData {
-        val selectedLoaders = loaderCheckBoxes.asSequence()
-            .mapNotNull { if (it.second.isSelected) it.first else null }.toList()
+        // Performance: Eager evaluation instead of .asSequence()...toList()
+        // since the list is very small (6 items), avoiding Sequence allocation overhead.
+        val selectedLoaders = loaderCheckBoxes
+            .mapNotNull { if (it.second.isSelected) it.first else null }
 
         val selectedMinecraftVersions = (0 until minecraftVersionModel.size)
             .mapNotNull { i -> minecraftVersionModel.getElementAt(i).takeIf { it.selected }?.version }


### PR DESCRIPTION
💡 What: Replaced `.filter { ... }.forEach { ... }` with a single `.forEach { if (...) { ... } }` and removed unnecessary sequence mapping (`.asSequence()...toList()`) for a small list in `PublishModDialog`. Added explanatory comments.
🎯 Why: To prevent unnecessary object allocation (intermediate `ArrayList` for `.filter` and iterator overhead for `.asSequence()`) on the Event Dispatch Thread (EDT) when rendering or submitting the UI dialog.
📊 Impact: Minor reduction in garbage collection overhead and faster execution in UI callback logic.
🔬 Measurement: Verify that modifying the mod list selections and closing/submitting the dialog completes seamlessly without introducing `ArrayList` instances in a profiler. Tested compilation and logic safety locally.

---
*PR created automatically by Jules for task [12690429682981471439](https://jules.google.com/task/12690429682981471439) started by @404Setup*